### PR TITLE
[OV-30] feat(product) : 상품 조회 기능 구현

### DIFF
--- a/product/src/main/java/com/owlexpress/product/domain/service/ProductDomainService.java
+++ b/product/src/main/java/com/owlexpress/product/domain/service/ProductDomainService.java
@@ -2,6 +2,7 @@ package com.owlexpress.product.domain.service;
 
 import com.owlexpress.product.presentation.dto.request.CreateProductRequestDto;
 import com.owlexpress.product.presentation.dto.request.UpdateProductDto;
+import com.owlexpress.product.presentation.dto.response.FindProductResponse;
 
 import java.util.UUID;
 
@@ -9,4 +10,6 @@ public interface ProductDomainService {
     void createProduct(CreateProductRequestDto mockingData);
 
     void updateProduct(UpdateProductDto mockingData, UUID productsId);
+
+    FindProductResponse find(UUID productsId);
 }

--- a/product/src/main/java/com/owlexpress/product/domain/service/ProductDomainServiceImpl.java
+++ b/product/src/main/java/com/owlexpress/product/domain/service/ProductDomainServiceImpl.java
@@ -4,6 +4,7 @@ import com.owlexpress.product.domain.repository.ProductRepository;
 import com.owlexpress.product.domain.entity.Product;
 import com.owlexpress.product.presentation.dto.request.CreateProductRequestDto;
 import com.owlexpress.product.presentation.dto.request.UpdateProductDto;
+import com.owlexpress.product.presentation.dto.response.FindProductResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,6 +35,13 @@ public class ProductDomainServiceImpl implements ProductDomainService {
         product.setProductName(updateProductDto.getProductName());
         product.setProductPrice(updateProductDto.getProductPrice());
         product.setProductType(updateProductDto.getProductType());
+    }
+
+    @Override
+    public FindProductResponse find(UUID productsId) {
+        Product product = getProduct(productsId);
+
+        return FindProductResponse.toDTO(product);
     }
 
     private Product getProduct(UUID productsId) {

--- a/product/src/main/java/com/owlexpress/product/domain/service/ProductDomainServiceImpl.java
+++ b/product/src/main/java/com/owlexpress/product/domain/service/ProductDomainServiceImpl.java
@@ -1,7 +1,7 @@
 package com.owlexpress.product.domain.service;
 
-import com.owlexpress.product.domain.repository.ProductRepository;
 import com.owlexpress.product.domain.entity.Product;
+import com.owlexpress.product.domain.repository.ProductRepository;
 import com.owlexpress.product.presentation.dto.request.CreateProductRequestDto;
 import com.owlexpress.product.presentation.dto.request.UpdateProductDto;
 import com.owlexpress.product.presentation.dto.response.FindProductResponse;
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Service
 @RequiredArgsConstructor
@@ -35,13 +36,24 @@ public class ProductDomainServiceImpl implements ProductDomainService {
         product.setProductName(updateProductDto.getProductName());
         product.setProductPrice(updateProductDto.getProductPrice());
         product.setProductType(updateProductDto.getProductType());
+
+        //TODO :: 변경된 상품 정보를 연결된 각 허브로 FeignClient 요청을 날려서 허브 수정 API 발동!
+        // (업데이트 시키는 동안 유저가 조회하지 못하게 막아야함)
     }
 
     @Override
     public FindProductResponse find(UUID productsId) {
         Product product = getProduct(productsId);
 
-        return FindProductResponse.toDTO(product);
+        AtomicInteger totalQuantity = new AtomicInteger(1000);
+
+        product.getHubInfo().stream().forEach(
+                hubInfo ->
+                        totalQuantity.addAndGet(hubInfo.getHubProductQuantity()) //TODO :: Hub에 재고조회 API 날려서 각 재고 모아오기
+        );
+
+
+        return FindProductResponse.toDTO(product,totalQuantity);
     }
 
     private Product getProduct(UUID productsId) {

--- a/product/src/main/java/com/owlexpress/product/presentation/ProductController.java
+++ b/product/src/main/java/com/owlexpress/product/presentation/ProductController.java
@@ -4,6 +4,7 @@ import com.owlexpress.product.common.CommonDto;
 import com.owlexpress.product.domain.service.ProductDomainService;
 import com.owlexpress.product.presentation.dto.request.CreateProductRequestDto;
 import com.owlexpress.product.presentation.dto.request.UpdateProductDto;
+import com.owlexpress.product.presentation.dto.response.FindProductResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -47,6 +48,23 @@ public class ProductController {
                 .status(HttpStatus.ACCEPTED)
                 .code(HttpStatus.ACCEPTED.value())
                 .message("상품 수정 성공")
+                .build();
+
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(commonDto);
+    }
+
+    @GetMapping("/{productsId}")
+    public ResponseEntity<CommonDto<FindProductResponse>> get(
+            //TODO:: gateway 반환 유저 데이터 @RequestHeader("X-User-Passport") String passport,
+            @PathVariable UUID productsId
+    ){
+        FindProductResponse findProductResponse= productDomainService.find(productsId);
+
+        CommonDto<FindProductResponse> commonDto = CommonDto.<FindProductResponse>builder()
+                .status(HttpStatus.OK)
+                .code(HttpStatus.OK.value())
+                .message("상품 조회 성공")
+                .data(findProductResponse)
                 .build();
 
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(commonDto);

--- a/product/src/main/java/com/owlexpress/product/presentation/dto/response/FindProductResponse.java
+++ b/product/src/main/java/com/owlexpress/product/presentation/dto/response/FindProductResponse.java
@@ -1,0 +1,40 @@
+package com.owlexpress.product.presentation.dto.response;
+
+import com.owlexpress.product.domain.constant.ProductType;
+import com.owlexpress.product.domain.entity.Product;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Data
+public class FindProductResponse {
+    private UUID productId;
+    private String productName;
+    private BigDecimal productPrice;
+    private ProductType productType;
+
+    @Builder
+    public FindProductResponse(
+            UUID productId,
+            String productName,
+            BigDecimal productPrice,
+            ProductType productType
+    )
+    {
+        this.productId = productId;
+        this.productName = productName;
+        this.productPrice = productPrice;
+        this.productType = productType;
+    }
+
+    public static FindProductResponse toDTO(Product product) {
+        return com.owlexpress.product.presentation.dto.response.FindProductResponse.builder()
+                .productName(product.getProductName())
+                .productId(product.getProductId())
+                .productType(product.getProductType())
+                .productPrice(product.getProductPrice())
+                .build();
+    }
+}

--- a/product/src/main/java/com/owlexpress/product/presentation/dto/response/FindProductResponse.java
+++ b/product/src/main/java/com/owlexpress/product/presentation/dto/response/FindProductResponse.java
@@ -7,6 +7,7 @@ import lombok.Data;
 
 import java.math.BigDecimal;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Data
 public class FindProductResponse {
@@ -14,27 +15,31 @@ public class FindProductResponse {
     private String productName;
     private BigDecimal productPrice;
     private ProductType productType;
+    private int totalQuantity;
 
     @Builder
     public FindProductResponse(
             UUID productId,
             String productName,
             BigDecimal productPrice,
-            ProductType productType
+            ProductType productType,
+            int totalQuantity
     )
     {
         this.productId = productId;
         this.productName = productName;
         this.productPrice = productPrice;
         this.productType = productType;
+        this.totalQuantity = totalQuantity;
     }
 
-    public static FindProductResponse toDTO(Product product) {
+    public static FindProductResponse toDTO(Product product, AtomicInteger totalQuantity) {
         return com.owlexpress.product.presentation.dto.response.FindProductResponse.builder()
                 .productName(product.getProductName())
                 .productId(product.getProductId())
                 .productType(product.getProductType())
                 .productPrice(product.getProductPrice())
+                .totalQuantity(totalQuantity.get())
                 .build();
     }
 }


### PR DESCRIPTION
- 상품 조회 기능 구현

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목
- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [x] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용
- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - 상품 조회 기능 추가 하였습니다.

## 참조
[OV-30](https://challduck.atlassian.net/browse/OV-30)

## 코멘트
이전에 생성한 dto를 메서드단위에 추가하지 않았었는데 빠뜨린 부분은 별도 이슈에 기록하고 한 번에 리팩토링 작업 하겠습니다!

또 상품 조회시에 존재하는 허브와 허브관리자목록을 출력할까 했는데 상품에 대한 조회이기에 이 부분은 제외하고 반환하도록 했습니다.
만약 유저가 상품 조회를 이 API를 통해 사용한다면 전체 재고수를 반환하는 데이터를 추가해야 할까 싶습니다. 코멘트 부탁드립니다!