### PR TITLE
[OV-46] Feat(producer) : 생산업체 서비스 수정 기능 구현

### DIFF
--- a/producer/src/main/java/com/owlexpress/producer/application/usecase/ProducerUsecase.java
+++ b/producer/src/main/java/com/owlexpress/producer/application/usecase/ProducerUsecase.java
@@ -1,15 +1,22 @@
 package com.owlexpress.producer.application.usecase;
 
-import com.owlexpress.producer.common.exception.ProducerException;
+import com.owlexpress.producer.common.util.GeoUtil;
 import com.owlexpress.producer.domain.entity.Producer;
 import com.owlexpress.producer.domain.repository.ProducerRepository;
 import com.owlexpress.producer.infrastructure.feignClient.HubFeignClient;
 import com.owlexpress.producer.infrastructure.feignClient.UserFeignClient;
-import com.owlexpress.producer.presentation.dto.request.CreateProducerRequestDto;
+import com.owlexpress.producer.common.dto.request.CreateProducerRequestDto;
+import com.owlexpress.producer.common.dto.request.UpdateProductRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.owlexpress.producer.common.exception.ProducerException.*;
 
 @Service
 @RequiredArgsConstructor
@@ -22,21 +29,60 @@ public class ProducerUsecase {
     @Transactional
     public void create(CreateProducerRequestDto createProducerRequestDto) {
 
-//        GetUserResponseDto findUserResponseDto = userFeignClient.get(createProducerRequestDto.getUserId());
+        //        GetUserResponseDto findUserResponseDto = userFeignClient.get(createProducerRequestDto.getUserId());
 
-//        GetHubResponseDto getUserResponseDto = HubhubFeignClient.get(createProducerRequestDto.getHubId());
+        //        GetHubResponseDto getUserResponseDto = HubhubFeignClient.get(createProducerRequestDto.getHubId());
 
-        //TODO:: client 통신 이후 코드 수정하기, 매개변수에 findUserResponseDto,GetUserResponseDto넣고 통신
-        //TODO :: 각 dto는 필요한 데이터를 가져오는 API를 생성해야 하나? 아니면 기존의 API 사용?
-        producerRepository.findByCompanyName(createProducerRequestDto.getCompanyName()).ifPresent(
-                producer -> {
-                    throw new ProducerException.ProducerNameDuplicateExceptoin("이미 존재하는 업체명입니다.");
-                }
-        );
+        producerRepository.findByCompanyName(createProducerRequestDto.getCompanyName())
+                          .ifPresent(producer -> {
+                              throw new ProducerNameDuplicateExceptoin("이미 존재하는 업체명입니다.");
+                          });
         Producer producer = CreateProducerRequestDto.toEntity(createProducerRequestDto);
         producer.updateCreateData(1L);
 
         producerRepository.save(producer);
 
+    }
+
+    @Transactional
+    public void update(
+            UpdateProductRequestDto updateProductRequestDto,
+            UUID producerId
+    ) {
+        //TODO:: 본인의 생성업체가 맞는지 확인 필요
+        // passport로 가져온 ID와 대조하기
+        Producer producer = getProducer(producerId);
+
+        //TODO:: 가져온 데이터의 정보를 통해 기존 producer의 데이터 수정
+        //        GetUserResponseDto findUserResponseDto = userFeignClient.get(createProducerRequestDto.getUserId());
+        //        GetHubResponseDto getUserResponseDto = HubhubFeignClient.get(createProducerRequestDto.getHubId());
+        updateProducer(producer, updateProductRequestDto);
+        producer.updateModifiedData(1L);
+
+        //TODO :: 생산업체 정보가 수정되었음을 연결된 허브 및 상품에 전파해야함
+        // 많은 곳에 FeignClient 통신을 보내야하기 때문에 메세지 큐의 필요성을 느끼게됨... 이벤트리스너야 보고싶다
+    }
+
+    private Producer getProducer(UUID producerId) {
+       return producerRepository.findById(producerId).orElseThrow(
+                ()-> new ProducerNotFoundException("찾는 영업이 존재하지 않습니다.")
+        );
+    }
+
+    public void updateProducer(Producer producer, UpdateProductRequestDto dto) {
+        //TODO:: 데이터를 어떤것만 가져올지 정책적으로 정한 후에 코드 수정하기
+        Optional.ofNullable(dto.getUserId()).ifPresent(producer::setUserId);
+        Optional.ofNullable(dto.getBusinessNumber()).ifPresent(producer::setBusinessNumber);
+        Optional.ofNullable(dto.getCompanyName()).ifPresent(producer::setCompanyName);
+        Optional.ofNullable(dto.getCompanyType()).ifPresent(producer::setCompanyType);
+        Optional.ofNullable(dto.getCompanyAddress()).ifPresent(producer::setCompanyAddress);
+        if(Optional.ofNullable(dto.getLatitude()).isPresent() && Optional.ofNullable(dto.getLongitude()).isPresent()){
+            Point point = GeoUtil.createPoint(
+                    dto.getLatitude(),
+                    dto.getLongitude()
+            );
+            producer.setLocation(point);
+        }
+        Optional.ofNullable(dto.getHubId()).ifPresent(producer::setHubId);
     }
 }

--- a/producer/src/main/java/com/owlexpress/producer/common/dto/request/CreateProducerRequestDto.java
+++ b/producer/src/main/java/com/owlexpress/producer/common/dto/request/CreateProducerRequestDto.java
@@ -1,4 +1,4 @@
-package com.owlexpress.producer.presentation.dto.request;
+package com.owlexpress.producer.common.dto.request;
 
 import com.owlexpress.producer.common.util.GeoUtil;
 import com.owlexpress.producer.domain.entity.Producer;
@@ -60,6 +60,7 @@ public class CreateProducerRequestDto {
                 .companyName(createProducerRequestDto.getCompanyName())
                 .companyType(createProducerRequestDto.getCompanyType())
                 .companyAddress(createProducerRequestDto.getCompanyAddress())
+                .userId(createProducerRequestDto.getUserId())
                 .userName("Admin")
                 .userPhoneNumber("010-1234-1234")
                 .hubId(createProducerRequestDto.getHubId())

--- a/producer/src/main/java/com/owlexpress/producer/common/dto/request/UpdateProductRequestDto.java
+++ b/producer/src/main/java/com/owlexpress/producer/common/dto/request/UpdateProductRequestDto.java
@@ -1,0 +1,56 @@
+package com.owlexpress.producer.common.dto.request;
+
+import com.owlexpress.producer.domain.entity.constant.CompanyType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class UpdateProductRequestDto {
+
+    //TODO:: 정보 수정시 모두 다시 받도록 체크?
+    @NotNull(message = "유저 ID값은 필수입니다.")
+    private Long userId;
+    @Size(min = 1, max = 20)
+    @NotNull(message = "사업자 번호는 필수값입니다.")
+    private String businessNumber;
+    @Size(min = 1, max = 20)
+    @NotNull(message = "회사명은 필수값입니다.")
+    private String companyName;
+    @NotNull(message = "회사 타입값은 필수값입니다.")
+    private CompanyType companyType;
+    @Size(min = 1, max = 255)
+    @NotNull(message = "회사 주소값은 필수값입니다.")
+    private String companyAddress;
+    @NotNull(message = "위도 값은 필수입니다.")
+    private Double latitude;
+    @NotNull(message = "경도 값은 필수입니다.")
+    private Double longitude;
+    @NotNull(message = "허브Id값은 필수값입니다.")
+    private UUID hubId;
+
+    @Builder
+    public UpdateProductRequestDto(
+            Long userId,
+            String businessNumber,
+            String companyName,
+            CompanyType companyType,
+            String companyAddress,
+            Double latitude,
+            Double longitude,
+            UUID hubId
+    ) {
+        this.userId = userId;
+        this.businessNumber = businessNumber;
+        this.companyName = companyName;
+        this.companyType = companyType;
+        this.companyAddress = companyAddress;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.hubId = hubId;
+    }
+
+}

--- a/producer/src/main/java/com/owlexpress/producer/common/dto/response/GetHubResponseDto.java
+++ b/producer/src/main/java/com/owlexpress/producer/common/dto/response/GetHubResponseDto.java
@@ -1,4 +1,4 @@
-package com.owlexpress.producer.application.dto.response;
+package com.owlexpress.producer.common.dto.response;
 
 import lombok.Builder;
 import lombok.Data;

--- a/producer/src/main/java/com/owlexpress/producer/common/dto/response/GetUserResponseDto.java
+++ b/producer/src/main/java/com/owlexpress/producer/common/dto/response/GetUserResponseDto.java
@@ -1,4 +1,4 @@
-package com.owlexpress.producer.application.dto.response;
+package com.owlexpress.producer.common.dto.response;
 
 import lombok.Data;
 

--- a/producer/src/main/java/com/owlexpress/producer/domain/entity/Producer.java
+++ b/producer/src/main/java/com/owlexpress/producer/domain/entity/Producer.java
@@ -4,10 +4,7 @@ import com.owlexpress.producer.common.BaseEntity;
 import com.owlexpress.producer.domain.entity.constant.CompanyType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +12,7 @@ import java.util.UUID;
 
 @Entity
 @Getter
+@Setter
 @Service
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_producer")
@@ -30,10 +28,13 @@ public class Producer extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "producer_id")
-    private UUID producer_id;
+    private UUID producerId;
     /**
      * 가져와야할 User(Owner) 값
      */
+
+    @Column(name = "user_id")
+    private Long userId;
 
     @Column(name = "user_name", nullable = false, unique = true)
     @Size(min = 1, max = 50)
@@ -66,6 +67,7 @@ public class Producer extends BaseEntity {
 
     @Builder
     public Producer(
+            Long userId,
             String userName,
             String userPhoneNumber,
             String businessNumber,
@@ -77,6 +79,7 @@ public class Producer extends BaseEntity {
             UUID hubManagerId,
             String hubAddress
     ) {
+        this.userId = userId;
         this.userName = userName;
         this.userPhoneNumber = userPhoneNumber;
         this.businessNumber = businessNumber;

--- a/producer/src/main/java/com/owlexpress/producer/domain/repository/ProducerRepository.java
+++ b/producer/src/main/java/com/owlexpress/producer/domain/repository/ProducerRepository.java
@@ -5,9 +5,12 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface ProducerRepository {
     Producer save(Producer producer);
 
     Optional<Producer> findByCompanyName(@Size(min = 1, max = 20) @NotNull(message = "회사명은 필수값입니다.") String companyName);
+
+    Optional<Producer> findById(UUID producerId);
 }

--- a/producer/src/main/java/com/owlexpress/producer/infrastructure/repository/ProducerRepositoryImpl.java
+++ b/producer/src/main/java/com/owlexpress/producer/infrastructure/repository/ProducerRepositoryImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 @RequiredArgsConstructor
@@ -20,5 +21,10 @@ public class ProducerRepositoryImpl implements ProducerRepository {
     @Override
     public Optional<Producer> findByCompanyName(String companyName) {
         return producerJpaRepository.findByCompanyName(companyName);
+    }
+
+    @Override
+    public Optional<Producer> findById(UUID producerId) {
+        return producerJpaRepository.findById(producerId);
     }
 }

--- a/producer/src/main/java/com/owlexpress/producer/presentation/controller/ProducerController.java
+++ b/producer/src/main/java/com/owlexpress/producer/presentation/controller/ProducerController.java
@@ -2,15 +2,15 @@ package com.owlexpress.producer.presentation.controller;
 
 import com.owlexpress.producer.application.usecase.ProducerUsecase;
 import com.owlexpress.producer.common.CommonDto;
-import com.owlexpress.producer.presentation.dto.request.CreateProducerRequestDto;
+import com.owlexpress.producer.common.dto.request.CreateProducerRequestDto;
+import com.owlexpress.producer.common.dto.request.UpdateProductRequestDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,12 +26,32 @@ public class ProducerController {
         producerUsecase.create(createProducerRequestDto);
 
         CommonDto<Object> commonDto = CommonDto.builder()
-                .status(HttpStatus.ACCEPTED)
-                .code(HttpStatus.ACCEPTED.value())
-                .message("생성업체 등록 성공")
-                .build();
+                                               .status(HttpStatus.ACCEPTED)
+                                               .code(HttpStatus.ACCEPTED.value())
+                                               .message("생성업체 등록 성공")
+                                               .build();
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(commonDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(commonDto);
+    }
+
+    @PutMapping("/{producerId}")
+    public ResponseEntity<CommonDto<Object>> update(
+            //TODO:: gateway 반환 유저 데이터 @RequestHeader("X-User-Passport") String passport,
+            @Valid @RequestBody UpdateProductRequestDto updateProductRequestDto,
+            @PathVariable UUID producerId
+
+    ) {
+        producerUsecase.update(updateProductRequestDto,producerId);
+        CommonDto<Object> commonDto = CommonDto.builder()
+                                               .status(HttpStatus.ACCEPTED)
+                                               .code(HttpStatus.ACCEPTED.value())
+                                               .message("생성업체 수정 성공")
+                                               .build();
+
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(commonDto);
     }
 
 


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목
- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [x] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용
- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - 생산업체 수정 기능 구현
    - 두 계층에서 사용하는 dto 를 common 패키지로 이동시킴
    - dto및 Entity에 빠진 필드 userId 추가

## 참조
[OV-46](https://challduck.atlassian.net/browse/OV-46)

## 코멘트
- 생산업체 수정 시 어떤 필드들을 수정가능하게 할 건지 제한사항도 이후에 고려해봐야 할 것 같습니다!
- 또한 생산업체 수정 시 전파해야 할 도메인에 대해 정리 후에 주석에 추가해두려고합니다.