### PR TITLE
Feat(alarm)/create alarm for company deliver

### DIFF
--- a/alarm/src/main/java/com/owl_express/alarm/application/dtos/response/AlarmCreateResponseDto.java
+++ b/alarm/src/main/java/com/owl_express/alarm/application/dtos/response/AlarmCreateResponseDto.java
@@ -1,0 +1,38 @@
+package com.owl_express.alarm.application.dtos.response;
+
+import com.owl_express.alarm.domain.entity.Notification;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AlarmCreateResponseDto {
+    private String platformMessageId;
+    private UUID alarmId;
+    private String message;
+
+    @Builder
+    public AlarmCreateResponseDto(
+            String platformMessageId,
+            UUID alarmId,
+            String message
+    ) {
+        this.platformMessageId = platformMessageId;
+        this.alarmId = alarmId;
+        this.message = message;
+    }
+
+    public static AlarmCreateResponseDto toDto(
+            Notification notification,
+            String platformMessageId
+    ) {
+        return AlarmCreateResponseDto.builder()
+                .platformMessageId(platformMessageId)
+                .alarmId(notification.getId())
+                .message(notification.getMessage())
+                .build();
+    }
+}

--- a/alarm/src/main/java/com/owl_express/alarm/application/exceptions/AlarmException.java
+++ b/alarm/src/main/java/com/owl_express/alarm/application/exceptions/AlarmException.java
@@ -20,6 +20,12 @@ public class AlarmException extends RuntimeException {
         }
     }
 
+    public static class NotSupportedMessageTypeException extends RuntimeException {
+        public NotSupportedMessageTypeException(String message) {
+            super(message);
+        }
+    }
+
     public static class SlackException extends RuntimeException {
         public SlackException(String message) {
             super(message);

--- a/alarm/src/main/java/com/owl_express/alarm/application/service/AlarmService.java
+++ b/alarm/src/main/java/com/owl_express/alarm/application/service/AlarmService.java
@@ -1,9 +1,11 @@
 package com.owl_express.alarm.application.service;
 
 import com.owl_express.alarm.application.dtos.request.AlarmCreateRequestDto;
+import com.owl_express.alarm.application.dtos.response.AlarmCreateResponseDto;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface AlarmService {
     void createAlarmForHubDeliver(AlarmCreateRequestDto alarmCreateRequestDto);
+    AlarmCreateResponseDto createAlarmForCompanyDeliver(AlarmCreateRequestDto alarmCreateRequestDto);
 }

--- a/alarm/src/main/java/com/owl_express/alarm/application/service/AlarmServiceImpl.java
+++ b/alarm/src/main/java/com/owl_express/alarm/application/service/AlarmServiceImpl.java
@@ -3,11 +3,16 @@ package com.owl_express.alarm.application.service;
 import com.owl_express.alarm.application.dtos.CommonDto;
 import com.owl_express.alarm.application.dtos.request.AlarmCreateRequestDto;
 import com.owl_express.alarm.application.dtos.request.MessageCreateRequestDto;
+import com.owl_express.alarm.application.dtos.response.AlarmCreateResponseDto;
 import com.owl_express.alarm.application.dtos.response.MessageCreateResponseDto;
+import com.owl_express.alarm.application.exceptions.AlarmException;
 import com.owl_express.alarm.application.exceptions.AlarmException.AiFeignClientException;
+import com.owl_express.alarm.application.exceptions.AlarmException.NotSupportedPlatformTypeException;
 import com.owl_express.alarm.application.exceptions.AlarmException.OrderNotFoundException;
 import com.owl_express.alarm.application.exceptions.AlarmException.SlackException;
+import com.owl_express.alarm.common.util.CommonUtil;
 import com.owl_express.alarm.domain.entity.Notification;
+import com.owl_express.alarm.domain.entity.Notification.MessageType;
 import com.owl_express.alarm.domain.entity.Notification.PlatformType;
 import com.owl_express.alarm.domain.repository.AlarmRepository;
 import com.owl_express.alarm.infrastructure.feignClient.AiClient;
@@ -16,14 +21,15 @@ import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
 import com.slack.api.methods.response.chat.ChatPostMessageResponse;
-import com.slack.api.webhook.Payload;
+import com.slack.api.methods.response.chat.ChatScheduleMessageResponse;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -53,31 +59,79 @@ public class AlarmServiceImpl implements AlarmService {
 
         //slack 전송
         PlatformType platformType = PlatformType.getType(requestDto.getPlatformName());
+        ChatPostMessageResponse chatPostMessageResponse;
 
         if(platformType.equals(PlatformType.SLACK)) {
-            sendMessage(messageCreateResponseDto.getMessage(), requestDto.getDeliverPlatformId());
+            chatPostMessageResponse = sendMessage(messageCreateResponseDto.getMessage(),
+                    requestDto.getDeliverPlatformId());
+
+            String gmtDate = chatPostMessageResponse.getHttpResponseHeaders().get("date").get(0);
+
+            //alarm 생성
+            Notification notification = Notification.builder()
+                    .aiId(messageCreateResponseDto.getAiId())
+                    .userId(requestDto.getUserId())
+                    .userPlatformId(requestDto.getDeliverPlatformId())
+                    .platformType(platformType)
+                    .message(messageCreateResponseDto.getMessage())
+                    .aiId(messageCreateResponseDto.getAiId())
+                    .sendAt(CommonUtil.gmtStringToDefaultLocalDateTime(gmtDate))
+                    .messageType(MessageType.NORMAL)
+                    .build();
+
+            // TODO : UserId 넣어주기
+            notification.createdEntity(1L);
+            alarmRepository.save(notification);
         }
-
-        //alarm 생성
-        Notification notification = Notification.builder()
-                .aiId(messageCreateResponseDto.getAiId())
-                .userId(requestDto.getUserId())
-                .userPlatformId(requestDto.getDeliverPlatformId())
-                .platformType(platformType)
-                .message(messageCreateResponseDto.getMessage())
-                .aiId(messageCreateResponseDto.getAiId())
-                .sendAt(LocalDateTime.now())
-                .isSend(true)
-                .build();
-
-        // TODO : UserId 넣어주기
-        notification.createdEntity(1L);
-
-        alarmRepository.save(notification);
-
     }
 
-    public MessageCreateResponseDto getMessageFromAi(AlarmCreateRequestDto requestDto, String productInfo) {
+    @Override
+    public AlarmCreateResponseDto createAlarmForCompanyDeliver(AlarmCreateRequestDto requestDto) {
+        // TODO : order service 생긴 후 feign client 통신으로 정보 얻어오기 or 배송쪽에서 product 정보 함께 넘기기(메세지큐 방식이면 괜찮을듯)
+        String productInfo = "생쭈꾸미 10마리, 냉동 쭈꾸미 1팩";
+
+        // TODO : ai 메세지 요청 feign client 통신 test
+        // MessageCreateResponseDto messageCreateResponseDto = getMessageFromAi(requestDto, productInfo);
+        //MockData
+        MessageCreateResponseDto messageCreateResponseDto
+                = MessageCreateResponseDto.builder()
+                .aiId(UUID.randomUUID())
+                .message("자 슬랙 메세지 전송 테스트 해보자 !")
+                .build();
+
+        //slack 전송
+        PlatformType platformType = PlatformType.getType(requestDto.getPlatformName());
+
+        if(platformType.equals(PlatformType.SLACK)) {
+            ChatScheduleMessageResponse chatScheduleMessageResponse
+                    = scheduleMessage(messageCreateResponseDto.getMessage(), requestDto.getDeliverPlatformId());
+
+            String platformMessageId = chatScheduleMessageResponse.getScheduledMessageId();
+            String gmtDate = chatScheduleMessageResponse.getHttpResponseHeaders().get("date").get(0);
+
+            //alarm 생성
+            Notification notification = Notification.builder()
+                    .aiId(messageCreateResponseDto.getAiId())
+                    .userId(requestDto.getUserId())
+                    .userPlatformId(requestDto.getDeliverPlatformId())
+                    .platformType(platformType)
+                    .message(messageCreateResponseDto.getMessage())
+                    .aiId(messageCreateResponseDto.getAiId())
+                    .sendAt(CommonUtil.gmtStringToDefaultLocalDateTime(gmtDate))
+                    .messageType(MessageType.RESERVATION)
+                    .messageId(platformMessageId)
+                    .build();
+
+            // TODO : UserId 넣어주기
+            notification.createdEntity(1L);
+            alarmRepository.save(notification);
+
+            return AlarmCreateResponseDto.toDto(notification, platformMessageId);
+        }
+        return AlarmCreateResponseDto.builder().build();
+    }
+
+    private MessageCreateResponseDto getMessageFromAi(AlarmCreateRequestDto requestDto, String productInfo) {
         MessageCreateResponseDto messageCreateResponseDto;
 
         try{
@@ -99,7 +153,8 @@ public class AlarmServiceImpl implements AlarmService {
         return messageCreateResponseDto;
     }
 
-    public void sendMessage(String message, String channelId) {
+    private ChatPostMessageResponse sendMessage(String message, String channelId) {
+        ChatPostMessageResponse response;
         try {
             MethodsClient client = Slack.getInstance().methods(slackBotToken);
 
@@ -110,10 +165,41 @@ public class AlarmServiceImpl implements AlarmService {
                     .unfurlMedia(true)
                     .build();
 
-            client.chatPostMessage(request);
+            response = client.chatPostMessage(request);
 
         } catch (IOException | SlackApiException e) {
             throw new SlackException(e.getMessage());
+        }
+
+        if(!(response == null) && response.isOk()) {
+            return response;
+        } else {
+            throw new SlackException("메세지 전송에 실패했습니다.");
+        }
+    }
+
+    private ChatScheduleMessageResponse scheduleMessage(String message, String channelId) {
+        ChatScheduleMessageResponse response;
+        LocalDateTime reserveTime = LocalDate.now().atTime(6, 00);
+
+        if (LocalDateTime.now().isAfter(reserveTime)) {
+            reserveTime = reserveTime.plusDays(1);
+        }
+
+        try {
+            LocalDateTime finalReserveTime = reserveTime;
+            response = Slack.getInstance().methods(slackBotToken)
+                    .chatScheduleMessage(r -> r.postAt((int) finalReserveTime.atZone(ZoneId.systemDefault()).toEpochSecond())
+                            .text(message)
+                            .channel(channelId));
+        } catch (IOException | SlackApiException e) {
+            throw new SlackException(e.getMessage());
+        }
+
+        if(!(response == null) && response.isOk()) {
+            return response;
+        } else {
+            throw new SlackException("메세지 예약에 실패했습니다.");
         }
     }
 

--- a/alarm/src/main/java/com/owl_express/alarm/common/advice/GlobalExceptionAdvice.java
+++ b/alarm/src/main/java/com/owl_express/alarm/common/advice/GlobalExceptionAdvice.java
@@ -2,6 +2,7 @@ package com.owl_express.alarm.common.advice;
 
 import com.owl_express.alarm.application.dtos.CommonDto;
 import com.owl_express.alarm.application.exceptions.AlarmException.AiFeignClientException;
+import com.owl_express.alarm.application.exceptions.AlarmException.NotSupportedMessageTypeException;
 import com.owl_express.alarm.application.exceptions.AlarmException.NotSupportedPlatformTypeException;
 import com.owl_express.alarm.application.exceptions.AlarmException.OrderNotFoundException;
 import com.owl_express.alarm.application.exceptions.AlarmException.SlackException;
@@ -79,6 +80,20 @@ public class GlobalExceptionAdvice {
     public CommonDto<Object> handlePlatformTypeNotSupportedException(NotSupportedPlatformTypeException e) {
 
         log.error("handlePlatformTypeNotSupportedException : {}", e.getMessage());
+
+        return CommonDto.builder()
+                .status(HttpStatus.NOT_FOUND)
+                .code(HttpStatus.NOT_FOUND.value())
+                .message(e.getMessage())
+                .data(null)
+                .build();
+    }
+
+    @ExceptionHandler(NotSupportedMessageTypeException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public CommonDto<Object> handleMessageTypeNotSupportedException(NotSupportedMessageTypeException e) {
+
+        log.error("handleMessageTypeNotSupportedException : {}", e.getMessage());
 
         return CommonDto.builder()
                 .status(HttpStatus.NOT_FOUND)

--- a/alarm/src/main/java/com/owl_express/alarm/common/util/CommonUtil.java
+++ b/alarm/src/main/java/com/owl_express/alarm/common/util/CommonUtil.java
@@ -1,15 +1,27 @@
 package com.owl_express.alarm.common.util;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 public class CommonUtil {
 
     private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter DayDateTimeFormatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH);
 
     public static String LocalDateTimetoString(LocalDateTime localDateTime) {
 
         return localDateTime == null ? null : localDateTime.format(dateTimeFormatter);
+    }
+
+    public static LocalDateTime gmtStringToDefaultLocalDateTime(String gmtDateString) {
+        ZonedDateTime gmtDateTime = ZonedDateTime.parse(gmtDateString, DayDateTimeFormatter);
+        ZonedDateTime localDateTime = gmtDateTime.withZoneSameInstant(ZoneId.systemDefault());
+
+        return localDateTime.toLocalDateTime();
+
     }
 
 }

--- a/alarm/src/main/java/com/owl_express/alarm/domain/entity/Notification.java
+++ b/alarm/src/main/java/com/owl_express/alarm/domain/entity/Notification.java
@@ -43,11 +43,15 @@ public class Notification extends BaseEntity {
     @Column(name = "send_at")
     private LocalDateTime sendAt;
 
-    @Column(name = "is_send", nullable = false)
-    private Boolean isSend = false;
-
     @Column(name = "ai_id", length = 50, nullable = false)
     private UUID aiId;
+
+    @Column(name = "message_id")
+    private String messageId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "message_type", nullable = false)
+    private MessageType messageType;
 
     @Builder
     public Notification(
@@ -56,16 +60,18 @@ public class Notification extends BaseEntity {
             PlatformType platformType,
             String message,
             LocalDateTime sendAt,
-            Boolean isSend,
-            UUID aiId
+            UUID aiId,
+            String messageId,
+            MessageType messageType
     ) {
         this.userId = userId;
         this.userPlatformId = userPlatformId;
         this.platformType = platformType;
         this.message = message;
         this.sendAt = sendAt;
-        this.isSend = isSend;
         this.aiId = aiId;
+        this.messageId = messageId;
+        this.messageType = messageType;
     }
 
     @RequiredArgsConstructor
@@ -81,6 +87,23 @@ public class Notification extends BaseEntity {
                 }
             }
             throw new NotSupportedPlatformTypeException("지원하지 않는 플랫폼 타입 입니다." + type);
+        }
+    }
+
+    @RequiredArgsConstructor
+    public enum MessageType{
+        NORMAL("일반 메세지"),
+        RESERVATION("예약 메세지");
+
+        private final String value;
+
+        public static MessageType getType(String type) {
+            for(MessageType mt : MessageType.values()) {
+                if(mt.value.equalsIgnoreCase(type)) {
+                    return mt;
+                }
+            }
+            throw new NotSupportedPlatformTypeException("지원하지 않는 메세지 타입 입니다." + type);
         }
     }
 }

--- a/alarm/src/main/java/com/owl_express/alarm/infrastructure/feignClient/AiClient.java
+++ b/alarm/src/main/java/com/owl_express/alarm/infrastructure/feignClient/AiClient.java
@@ -5,7 +5,6 @@ import com.owl_express.alarm.application.dtos.request.MessageCreateRequestDto;
 import com.owl_express.alarm.application.dtos.response.MessageCreateResponseDto;
 import jakarta.validation.Valid;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 

--- a/alarm/src/main/java/com/owl_express/alarm/presentation/AlarmController.java
+++ b/alarm/src/main/java/com/owl_express/alarm/presentation/AlarmController.java
@@ -2,6 +2,7 @@ package com.owl_express.alarm.presentation;
 
 import com.owl_express.alarm.application.dtos.CommonDto;
 import com.owl_express.alarm.application.dtos.request.AlarmCreateRequestDto;
+import com.owl_express.alarm.application.dtos.response.AlarmCreateResponseDto;
 import com.owl_express.alarm.application.service.AlarmService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,22 @@ public class AlarmController {
                         .data(null)
                         .build());
     }
+
+    @PostMapping("/company-delivery")
+    public ResponseEntity<CommonDto<AlarmCreateResponseDto>> createAlarmForCompanyDeliver(
+            @Valid @RequestBody AlarmCreateRequestDto alarmCreateRequestDto
+    ) {
+        AlarmCreateResponseDto response = alarmService.createAlarmForCompanyDeliver(alarmCreateRequestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                CommonDto.<AlarmCreateResponseDto>builder()
+                        .status(HttpStatus.CREATED)
+                        .message("알림 예약 완료")
+                        .code(HttpStatus.CREATED.value())
+                        .data(response)
+                        .build());
+    }
+
 
 
 }


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목
- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [x] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용
- **as-is**
    - send_at을 slack 전송 작업 이후, spring 서버에서 현재 시간으로 저장

- **to-be**
    - send_at을 slack에서 실제로 보낸 시간 응답을 받아와서 한국 시간으로 변환해 저장
    - 예약 메세지 기능 구현

## 참조
[OV-13](https://challduck.atlassian.net/browse/OV-13)

## 코멘트
여러분의 도움이 필요합니다 !! 제가 코드 짜면서 가장 어려워하는 게 조금 복잡해지는 로직이 있는 경우 읽기 쉬운 코드를 작성하는 일 같아요 단일 책임 원칙에 맞게 최대한 작성하려고 하지만, 세세한 부분까지 메서드로 다 분리하자니 메서드 확인하러 너무 왔다갔다하는데 시간이 걸릴 것 같고.. 적당선을 찾는 게 항상 어렵습니다 현재 CreateAlarmForHubDeliver와 CreateAlarmForCompanyDeliver가 지저분해서 refactoring이 필요해보이는데.. 아이디어가 있으시다면 주시면 정말 정말 감사하겠습니다


- 57 분에 일반 메세지/예약 메세지를 날렸어요
![image](https://github.com/user-attachments/assets/83b974e0-ece3-43ba-9ee9-3591b87cad41)

- 예약 메세지는 6시에 도착했어요 (왼쪽 하단에 6:00)
![image](https://github.com/user-attachments/assets/117ce277-dd49-440e-ab6c-7429ab3d5223)