### PR TITLE
[OV-154] feat(order): 주문 서비스 controller 구현 (#199)

### DIFF
--- a/order/src/main/java/com/owlexpress/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/owlexpress/order/presentation/controller/OrderController.java
@@ -1,0 +1,140 @@
+package com.owlexpress.order.presentation.controller;
+
+import static com.owlexpress.order.presentation.dto.ApiResponseMessageConstant.CREATE_ORDER_SUCCESS_MESSAGE;
+import static com.owlexpress.order.presentation.dto.ApiResponseMessageConstant.DELETE_ORDER_SUCCESS_MESSAGE;
+import static com.owlexpress.order.presentation.dto.ApiResponseMessageConstant.FIND_ORDER_SUCCESS_MESSAGE;
+import static com.owlexpress.order.presentation.dto.ApiResponseMessageConstant.SEARCH_ORDER_SUCCESS_MESSAGE;
+import static com.owlexpress.order.presentation.dto.ApiResponseMessageConstant.UPDATE_ORDER_SUCCESS_MESSAGE;
+
+import com.owlexpress.order.application.service.OrderService;
+import com.owlexpress.order.common.CommonDto;
+import com.owlexpress.order.presentation.dto.request.CreateOrderRequestDto;
+import com.owlexpress.order.presentation.dto.request.UpdateOrderRequestDto;
+import com.owlexpress.order.presentation.dto.response.CreateOrderResponseDto;
+import com.owlexpress.order.presentation.dto.response.GetOrderResponseDto;
+import com.owlexpress.order.presentation.dto.response.OrderSearchResponseDto;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.web.PagedModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+public class OrderController {
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<CommonDto<CreateOrderResponseDto>> createOrder(
+            @RequestBody CreateOrderRequestDto request
+    ) {
+        Long userId = 1L;
+
+        CreateOrderResponseDto responseDto = orderService.createOrder(userId, request);
+
+        CommonDto<CreateOrderResponseDto> commonDto = CommonDto
+                .<CreateOrderResponseDto>builder()
+                .status(HttpStatus.CREATED)
+                .code(HttpStatus.CREATED.value())
+                .message(CREATE_ORDER_SUCCESS_MESSAGE)
+                .data(responseDto)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(commonDto);
+    }
+
+    @GetMapping("/{orderId}")
+    public ResponseEntity<CommonDto<GetOrderResponseDto>> findOrder(
+        @PathVariable("orderId") UUID orderId
+    ){
+        GetOrderResponseDto response = orderService.findOrder(orderId);
+
+        CommonDto<GetOrderResponseDto> commonDto = CommonDto
+                .<GetOrderResponseDto>builder()
+                .status(HttpStatus.OK)
+                .code(HttpStatus.OK.value())
+                .message(FIND_ORDER_SUCCESS_MESSAGE)
+                .data(response)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(commonDto);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<CommonDto<PagedModel<OrderSearchResponseDto>>> search(
+            @RequestParam(name = "page", defaultValue = "1") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size,
+            @RequestParam(name = "sort", defaultValue = "createdAt") String sort,
+            @RequestParam(name = "order_by", defaultValue = "ASC") String orderBy,
+            @RequestParam(name = "start_date", required = false) String startDate,
+            @RequestParam(name = "end_date", required = false) String endDate
+    ){
+        PagedModel<OrderSearchResponseDto> response = orderService.search(
+                page,
+                size,
+                sort,
+                orderBy,
+                startDate,
+                endDate
+        );
+
+        CommonDto<PagedModel<OrderSearchResponseDto>> commonDto = CommonDto
+                .<PagedModel<OrderSearchResponseDto>>builder()
+                .status(HttpStatus.OK)
+                .code(HttpStatus.OK.value())
+                .message(SEARCH_ORDER_SUCCESS_MESSAGE)
+                .data(response)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(commonDto);
+    }
+
+    @PatchMapping("/{orderId}")
+    public ResponseEntity<CommonDto<Void>> update(
+            @PathVariable("orderId") UUID orderId,
+            @RequestBody UpdateOrderRequestDto requestDto
+    ){
+        Long userId = 1L;
+
+        orderService.updateOrder(orderId, requestDto, userId);
+
+        CommonDto<Void> commonDto = CommonDto
+                .<Void>builder()
+                .status(HttpStatus.ACCEPTED)
+                .code(HttpStatus.ACCEPTED.value())
+                .message(UPDATE_ORDER_SUCCESS_MESSAGE)
+                .data(null)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(commonDto);
+    }
+
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<CommonDto<Void>> delete(
+            @PathVariable("orderId") UUID orderId
+    ){
+        Long userId = 1L;
+
+        orderService.deleteOrder(orderId, userId);
+
+        CommonDto<Void> commonDto = CommonDto
+                .<Void>builder()
+                .status(HttpStatus.ACCEPTED)
+                .code(HttpStatus.ACCEPTED.value())
+                .message(DELETE_ORDER_SUCCESS_MESSAGE)
+                .data(null)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(commonDto);
+    }
+}

--- a/order/src/main/java/com/owlexpress/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/owlexpress/order/presentation/controller/OrderController.java
@@ -53,9 +53,9 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.CREATED).body(commonDto);
     }
 
-    @GetMapping("/{orderId}")
+    @GetMapping("/{order_id}")
     public ResponseEntity<CommonDto<GetOrderResponseDto>> findOrder(
-        @PathVariable("orderId") UUID orderId
+        @PathVariable("order_id") UUID orderId
     ){
         GetOrderResponseDto response = orderService.findOrder(orderId);
 
@@ -99,9 +99,9 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.OK).body(commonDto);
     }
 
-    @PatchMapping("/{orderId}")
+    @PatchMapping("/{order_id}")
     public ResponseEntity<CommonDto<Void>> update(
-            @PathVariable("orderId") UUID orderId,
+            @PathVariable("order_id") UUID orderId,
             @RequestBody UpdateOrderRequestDto requestDto
     ){
         Long userId = 1L;
@@ -119,9 +119,9 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(commonDto);
     }
 
-    @DeleteMapping("/{orderId}")
+    @DeleteMapping("/{order_id}")
     public ResponseEntity<CommonDto<Void>> delete(
-            @PathVariable("orderId") UUID orderId
+            @PathVariable("order_id") UUID orderId
     ){
         Long userId = 1L;
 

--- a/order/src/main/java/com/owlexpress/order/presentation/dto/ApiResponseMessageConstant.java
+++ b/order/src/main/java/com/owlexpress/order/presentation/dto/ApiResponseMessageConstant.java
@@ -1,5 +1,9 @@
 package com.owlexpress.order.presentation.dto;
 
 public class ApiResponseMessageConstant {
-
+    public static final String CREATE_ORDER_SUCCESS_MESSAGE = "주문 생성 성공";
+    public static final String FIND_ORDER_SUCCESS_MESSAGE = "주문 조회 성공";
+    public static final String SEARCH_ORDER_SUCCESS_MESSAGE = "주문 검색 조회 성공";
+    public static final String UPDATE_ORDER_SUCCESS_MESSAGE = "주문 수정 성공";
+    public static final String DELETE_ORDER_SUCCESS_MESSAGE = "주문 삭제 성공";
 }


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목
- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용
- **as-is**
    - order controller 미구현

- **to-be**
    - Order 생성 API 구현
    - Order 삭제 API 구현
    - Order description 수정 API 구현
    - Order Page 처리 API 구현
    - Order 단일 조회 API 구현
    - Order controller commonDto 내 응답값 분리

## 참조
[OV-154](https://challduck.atlassian.net/browse/OV-154)

## 코멘트
- resolve #199 