### PR TITLE
[OV-195] bug(cart): 장바구니 서비스 삭제 API 경로 중복 문제 (#282)

### DIFF
--- a/cart/src/main/java/com/owlexpress/cart/presentation/CartController.java
+++ b/cart/src/main/java/com/owlexpress/cart/presentation/CartController.java
@@ -127,7 +127,7 @@ public class CartController {
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(commonDto);
     }
 
-    @DeleteMapping("/{consumerId}")
+    @DeleteMapping("/remove/{consumerId}")
     public ResponseEntity<CommonDto<Void>> deleteCart(
             @RequestHeader("X-User-Passport") String passport,
             @PathVariable("consumerId") UUID consumerId


### PR DESCRIPTION
## 변경 타입
- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목
- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용
- **as-is**
    - 장바구니 삭제 및 장바구니 상품 삭제 API 경로 중복 문제

- **to-be**
    - 삭제 Api path 수정

## 참조
[OV-195](https://challduck.atlassian.net/browse/OV-195)

## 코멘트
- resolve #282 